### PR TITLE
Fix broadcast: exclude sender via client IDs

### DIFF
--- a/apps/audio-call/index.html
+++ b/apps/audio-call/index.html
@@ -35,7 +35,7 @@
   <audio id="remoteAudio" autoplay></audio>
 </div>
 <script>
-let es, pc, localStream, muted = false;
+let es, pc, localStream, muted = false, myId = null;
 
 const SERVER = "https://shooka.tail2fbae.ts.net";
 const status = document.getElementById("status");
@@ -53,7 +53,7 @@ function send(data) {
   fetch(SERVER + "/signal", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
+    body: JSON.stringify({ ...data, senderId: myId }),
   });
 }
 
@@ -119,6 +119,9 @@ async function answerCall() {
 
 async function handleSignal(msg) {
   switch (msg.type) {
+    case "welcome":
+      myId = msg.id;
+      return;
     case "ring":
       setStatus("Incoming call...");
       answerBtn.style.display = "inline-block";

--- a/apps/audio-call/server.js
+++ b/apps/audio-call/server.js
@@ -4,10 +4,10 @@ const PORT = process.env.PORT || 3000;
 const clients = new Set();
 let clientId = 0;
 
-function broadcast(sender, data) {
+function broadcast(senderId, data) {
   const msg = `data: ${JSON.stringify(data)}\n\n`;
   for (const c of clients) {
-    if (c !== sender) c.res.write(msg);
+    if (c.id !== senderId) c.res.write(msg);
   }
 }
 
@@ -28,14 +28,15 @@ const server = http.createServer((req, res) => {
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
     });
-    res.write(":\n\n");
-    const client = { id: ++clientId, res };
+    const id = ++clientId;
+    res.write(`data: ${JSON.stringify({ type: "welcome", id })}\n\n`);
+    const client = { id, res };
     clients.add(client);
     console.log(`+ client ${client.id} (${clients.size} total)`);
     req.on("close", () => {
       clients.delete(client);
       console.log(`- client ${client.id} (${clients.size} total)`);
-      broadcast(client, { type: "peer-left" });
+      broadcast(client.id, { type: "peer-left" });
     });
     return;
   }
@@ -45,7 +46,7 @@ const server = http.createServer((req, res) => {
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
       const msg = JSON.parse(body);
-      broadcast(null, msg);
+      broadcast(msg.senderId, msg);
       res.writeHead(200);
       res.end("ok");
     });


### PR DESCRIPTION
## Summary
- Server assigns each SSE client an ID on connect
- Clients include their ID in POST signals
- Server excludes sender from broadcast, preventing echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)