### PR TITLE
Switch signaling from SSE to HTTP polling

### DIFF
--- a/apps/audio-call/index.html
+++ b/apps/audio-call/index.html
@@ -35,7 +35,7 @@
   <audio id="remoteAudio" autoplay></audio>
 </div>
 <script>
-let es, pc, localStream, muted = false, myId = null;
+let pc, localStream, muted = false, myId = null, pollTimer = null;
 
 const SERVER = "https://shooka.tail2fbae.ts.net";
 const status = document.getElementById("status");
@@ -57,14 +57,26 @@ function send(data) {
   });
 }
 
-function connect() {
-  es = new EventSource(SERVER + "/events");
-  es.onopen = () => {
+async function connect() {
+  try {
+    const res = await fetch(SERVER + "/connect");
+    const data = await res.json();
+    myId = data.id;
     setStatus("Connected - waiting for others");
     controls.style.display = "block";
-  };
-  es.onerror = () => setStatus("Connection failed");
-  es.onmessage = (e) => handleSignal(JSON.parse(e.data));
+    pollTimer = setInterval(poll, 500);
+  } catch (e) {
+    setStatus("Connection failed");
+  }
+}
+
+async function poll() {
+  try {
+    const res = await fetch(SERVER + "/poll?id=" + myId);
+    if (!res.ok) return;
+    const msgs = await res.json();
+    for (const msg of msgs) handleSignal(msg);
+  } catch (e) { /* network hiccup, retry next tick */ }
 }
 
 connect();
@@ -119,9 +131,6 @@ async function answerCall() {
 
 async function handleSignal(msg) {
   switch (msg.type) {
-    case "welcome":
-      myId = msg.id;
-      return;
     case "ring":
       setStatus("Incoming call...");
       answerBtn.style.display = "inline-block";

--- a/apps/audio-call/server.js
+++ b/apps/audio-call/server.js
@@ -1,14 +1,29 @@
 const http = require("http");
 const PORT = process.env.PORT || 3000;
 
-const clients = new Set();
+const clients = new Map(); // id -> { queue: [], lastPoll: Date.now() }
 let clientId = 0;
 
-function broadcast(senderId, data) {
-  const msg = `data: ${JSON.stringify(data)}\n\n`;
-  for (const c of clients) {
-    if (c.id !== senderId) c.res.write(msg);
+// Expire clients that haven't polled in 10s
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, client] of clients) {
+    if (now - client.lastPoll > 10000) {
+      clients.delete(id);
+      console.log(`- client ${id} expired (${clients.size} total)`);
+      broadcast(id, { type: "peer-left" });
+    }
   }
+}, 3000);
+
+function broadcast(senderId, data) {
+  for (const [id, client] of clients) {
+    if (id !== senderId) client.queue.push(data);
+  }
+}
+
+function parseURL(url) {
+  return new URL(url, "http://localhost");
 }
 
 const server = http.createServer((req, res) => {
@@ -22,26 +37,33 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  if (req.url === "/events" && req.method === "GET") {
-    res.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    });
+  const parsed = parseURL(req.url);
+
+  if (parsed.pathname === "/connect" && req.method === "GET") {
     const id = ++clientId;
-    res.write(`data: ${JSON.stringify({ type: "welcome", id })}\n\n`);
-    const client = { id, res };
-    clients.add(client);
-    console.log(`+ client ${client.id} (${clients.size} total)`);
-    req.on("close", () => {
-      clients.delete(client);
-      console.log(`- client ${client.id} (${clients.size} total)`);
-      broadcast(client.id, { type: "peer-left" });
-    });
+    clients.set(id, { queue: [], lastPoll: Date.now() });
+    console.log(`+ client ${id} (${clients.size} total)`);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ id }));
     return;
   }
 
-  if (req.url === "/signal" && req.method === "POST") {
+  if (parsed.pathname === "/poll" && req.method === "GET") {
+    const id = Number(parsed.searchParams.get("id"));
+    const client = clients.get(id);
+    if (!client) {
+      res.writeHead(404);
+      res.end(JSON.stringify({ error: "unknown client" }));
+      return;
+    }
+    client.lastPoll = Date.now();
+    const msgs = client.queue.splice(0);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(msgs));
+    return;
+  }
+
+  if (parsed.pathname === "/signal" && req.method === "POST") {
     let body = "";
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {


### PR DESCRIPTION
## Summary
- Replace SSE (`EventSource`) with HTTP polling to work through Tailscale Funnel (which overrides `Content-Type` to `text/plain`)
- Server: `GET /connect` assigns client ID, `GET /poll?id=X` returns queued messages, clients auto-expire after 10s
- Client: polls every 500ms via `fetch`, no more `EventSource` dependency

## Test plan
- [x] `curl /connect` returns `{"id":1}`
- [ ] Open in two browsers, verify "Connected" status
- [ ] Test call/answer/decline/hangup flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)